### PR TITLE
Add datetime to set_type of DateTimeField

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -451,6 +451,7 @@ class TimeField(DateTimeCheckMixin, Field[_ST, _GT]):
     ): ...
 
 class DateTimeField(DateField[_ST, _GT]):
+    _pyi_private_set_type: Union[str, datetime, date, Combinable]
     _pyi_private_get_type: datetime
     _pyi_lookup_exact_type: Union[str, datetime]
 

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -127,7 +127,7 @@
         from myapp.models import Publisher, PublisherDatetime, Book
         Book(publisher_id=1, publisher_dt_id=now)
         Book(publisher_id=[], publisher_dt_id=now)  # E: Incompatible type for "publisher_id" of "Book" (got "List[Any]", expected "Union[Combinable, int, str, None]")
-        Book(publisher_id=1, publisher_dt_id=1)  # E: Incompatible type for "publisher_dt_id" of "Book" (got "int", expected "Union[str, date, Combinable, None]")
+        Book(publisher_id=1, publisher_dt_id=1)  # E: Incompatible type for "publisher_dt_id" of "Book" (got "int", expected "Union[str, datetime, date, Combinable, None]")
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
`DateTimeField` was missing `datetime` as a valid set type. But Django clearly accepts `datetime`.